### PR TITLE
Increase OSM response timeout

### DIFF
--- a/shared/source-osm/generate-fetch-osm-objects.ts
+++ b/shared/source-osm/generate-fetch-osm-objects.ts
@@ -31,7 +31,7 @@ export const generateFetchOsmObjects =
     output.write(chalk.bold(`sources/osm: Fetching ${title}\n`));
 
     const query = dedent`
-      [out:json][timeout:60];
+      [out:json][timeout:250];
       (${selectors
         .map((selector) => `\n      ${selector}({{extent}});`)
         .join("")}


### PR DESCRIPTION
Текущее время - 60 секунд недостаточно для скачивания всех объектов (домов или дорог) в большом городе, я увеличил до 250, этого не влияет на время ожидания, но минимизирует шанс пустого ответа.